### PR TITLE
OCTOPUS-612/613: Changes are made to patch nfs-provisioner deployment

### DIFF
--- a/openstack/intel-worker/tasks/patch-nfs-deployment-for-mac-worker.yml
+++ b/openstack/intel-worker/tasks/patch-nfs-deployment-for-mac-worker.yml
@@ -1,0 +1,35 @@
+---
+- name: Patch nfs-client-provisioner deployment to run on master node
+  hosts: all
+  vars_files:
+    - ../vars/main.yml
+
+  tasks:
+  - name: Check if nfs-client-provisioner deployment exists
+    shell:
+      cmd: |
+        oc get deployment "{{ nfs_deployment }}" -n "{{ nfs_namespace }}"
+    register: nfs_deploy_output
+
+  - name: Patch nfs-client-provisioner deployment to run on master node
+    shell:
+      cmd: |
+        oc patch deployments "{{ nfs_deployment }}" -n "{{ nfs_namespace }}" -p '{"spec": {"template": {"spec": {"tolerations": [{"effect": "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}}'
+        oc patch deployments "{{ nfs_deployment }}" -n "{{ nfs_namespace }}" -p '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/master": ""}}}}}'
+    when: nfs_deploy_output.stdout != ""
+
+  - name: Get nfs-client-provisioner deployment Image
+    shell:
+      cmd: |
+         oc describe deployment "{{ nfs_deployment }}" -n "{{ nfs_namespace }}" | grep Image
+    register: nfs_image_output
+    when: nfs_deploy_output.stdout != ""
+
+  - name: Check and update Image (if belongs to 'gcr.io/k8s-staging-sig-storage') of nfs-client-provisioner deployment to 'registry.k8s.io/sig-storage'
+    shell:
+      cmd: |
+         oc patch deployment "{{ nfs_deployment }}" -n "{{ nfs_namespace }}" --type "json" -p '[
+          {"op":"remove","path":"/spec/template/spec/containers/0/image"},
+          {"op":"add","path":"/spec/template/spec/containers/0/image","value":"registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2"}]'
+    when: "'gcr.io' in nfs_image_output.stdout"
+

--- a/openstack/intel-worker/vars/main.yml
+++ b/openstack/intel-worker/vars/main.yml
@@ -1,16 +1,19 @@
 ---
-bastion_ip: ""
-worker_hostname: ""
-http_port: "8080"
-https_port: "443"
 
 # Used in ignition task
+worker_hostname: ""
 worker_hostname_encoded: ""
 etc_resolve_encoded: ""
-target_ip: ""
+bastion_ip: ""
 domain_name: ""
+http_port: "8080"
+https_port: "443"
 
 # Ignition Files
 dns_none_conf: |-
   [main]
   dns=none
+
+# Used in patch nfs deployment task
+nfs_namespace: "nfs-provisioner"
+nfs_deployment: "nfs-client-provisioner"


### PR DESCRIPTION
Changes are made to patch nfs-provisioner deployment for following
- NFS Pod should run on master node
- If NFS Pod is using 'gcr.io/k8s-staging-sig-storage' based image then change it to 'registry.k8s.io/sig-storage'
