### PR TITLE
Destroy intel worker node and minor other changes

### DIFF
--- a/openstack/intel-worker/playbooks/intel-worker-cleanup-playbook.yml
+++ b/openstack/intel-worker/playbooks/intel-worker-cleanup-playbook.yml
@@ -1,8 +1,24 @@
 ---
-- name: Intel worker vitrual_machine delete
+- name: Destory intel worker node
   hosts: localhost
   roles:
-    - virtual_machine_delete
+    - destroy_worker
+  vars:
+    destroy_worker_intel_count: 3
+
+- name: Loop over virtual machine delete role in the playbook with dynamic variable names
+  hosts: localhost
+  vars:
+    iterations: 3  # Number of iterations for the loop
+  tasks:
+    - name: Virtual machine delete role in loop
+      ansible.builtin.include_role:
+        name: virtual_machine_delete
+      loop: "{{ range(0, iterations) | list }}"
+      loop_control:
+        loop_var: iteration
+      vars:
+        virtual_machine_delete_name: "rdr-mac-worker-openstack-{{ iteration }}"
 
 - name: Intel worker flavor create
   hosts: localhost

--- a/openstack/intel-worker/playbooks/intel-worker-playbook.yml
+++ b/openstack/intel-worker/playbooks/intel-worker-playbook.yml
@@ -12,12 +12,12 @@
 - name: Loop over virtual machine create role in the playbook with dynamic variable names
   hosts: localhost
   vars:
-    iterations: "{{ virtual_machine_create_count }}"  # Number of iterations for the loop
+    iterations: 3  # Number of iterations for the loop
   tasks:
     - name: Virtual machine create role in loop
       ansible.builtin.include_role:
         name: virtual_machine_create
-      loop: "{{ range(1, iterations + 1) | list }}"
+      loop: "{{ range(0, iterations) | list }}"
       loop_control:
         loop_var: iteration
       vars:
@@ -28,6 +28,8 @@
   hosts: localhost
   roles:
     - approve_and_issue
+  vars:
+    approve_and_issue_intel_count: 3
 
 - name: Intel worker vitrual_machine create
   hosts: localhost

--- a/openstack/intel-worker/playbooks/roles/approve_and_issue/defaults/main.yml
+++ b/openstack/intel-worker/playbooks/roles/approve_and_issue/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # Approve and issue vars
-approve_and_issue_intel_count: 1
+approve_and_issue_intel_count: 3
 approve_and_issue_intel_prefix: "rdr-mac"
 approve_and_issue_intel_zone: "openstack"

--- a/openstack/intel-worker/playbooks/roles/destroy_worker/defaults/main.yml
+++ b/openstack/intel-worker/playbooks/roles/destroy_worker/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Approve and issue vars
+destroy_worker_intel_count: 3
+destroy_worker_intel_prefix: "rdr-mac"
+destroy_worker_intel_zone: "openstack"

--- a/openstack/intel-worker/playbooks/roles/destroy_worker/files/destroy_worker.sh
+++ b/openstack/intel-worker/playbooks/roles/destroy_worker/files/destroy_worker.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+################################################################
+# Copyright 2024 - IBM Corporation. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+################################################################
+
+# Approve and Issue CSRs for our generated amd64 workers only
+# The hostname is of the style - ${name_prefix}-worker-${ZONE}-${index}
+
+# Var: ${self.triggers.counts}
+INTEL_COUNT="${1}"
+
+# Var: ${self.triggers.approve}
+INTEL_PREFIX="${2}"
+
+INTEL_ZONE="${3}"
+
+# Machine Prefix
+MACHINE_PREFIX="${INTEL_PREFIX}-worker-${INTEL_ZONE}"
+
+IDX=0
+while [ "$IDX" -lt "$INTEL_COUNT" ]
+do
+    echo "Removing the Worker Zone ${INTEL_ZONE}: ${MACHINE_PREFIX}-${IDX}"
+    oc delete node ${MACHINE_PREFIX}-${IDX} || true
+    IDX=$(($IDX + 1))
+done

--- a/openstack/intel-worker/playbooks/roles/destroy_worker/tasks/main.yml
+++ b/openstack/intel-worker/playbooks/roles/destroy_worker/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# file to add the destory worker node
+- name: Copy the destory worker node file to tmp folder
+  ansible.builtin.copy:
+    src: "{{ role_path }}/files/destroy_worker.sh"
+    dest: /tmp/destroy_worker.sh
+    mode: "0755"
+
+- name: Run the script to destory worker node
+  ansible.builtin.script:
+    cmd: /tmp/destroy_worker.sh "{{ destroy_worker_intel_count }}" "{{ destroy_worker_intel_prefix }}" "{{ destroy_worker_intel_zone }}"
+    register: destroy_node_ouptut

--- a/openstack/intel-worker/playbooks/roles/virtual_machine_delete/defaults/main.yml
+++ b/openstack/intel-worker/playbooks/roles/virtual_machine_delete/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # Virtual_machine details
-virtual_machine_delete_name: rdr-mac-worker
+virtual_machine_delete_name: rdr-mac-worker-openstack
+virtual_machine_delete_count: 3


### PR DESCRIPTION
Destroy intel worker node and minor other changes

 ```
"Removing the Worker Zone openstack: rdr-mac-worker-openstack-0",
"Removing the Worker Zone openstack: rdr-mac-worker-openstack-1",
"Removing the Worker Zone openstack: rdr-mac-worker-openstack-2"
```

Also it will delete the VM from the intel openstack cloud . 